### PR TITLE
chore: replace dependabot npm updates with self-hosted weekly pnpm-update workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,12 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 # https://docs.github.com/ja/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
 
+# npm dependency updates are handled by the self-hosted `.github/workflows/pnpm-update.yml`
+# workflow (weekly `pnpm update` + `pnpm self-update`). Dependabot only keeps
+# GitHub Actions up to date here, since those cannot be updated by `pnpm update`.
+
 version: 2
 updates:
-  - package-ecosystem: 'npm' # See documentation for possible values
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-    cooldown:
-      default-days: 7
-    target-branch: 'main'
-    commit-message:
-      prefix: 'fix'
-      prefix-development: 'chore'
-    ignore:
-      - dependency-name: 'typescript'
-        versions: ['>=6.0.0']
-
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/.github/workflows/pnpm-update.yml
+++ b/.github/workflows/pnpm-update.yml
@@ -1,0 +1,86 @@
+name: Weekly pnpm update
+
+# Runs this repository's own `update-packages` script (which encodes the
+# skip rules such as `!eslint` / `!typescript`) together with `pnpm
+# self-update`, and opens a single bundled pull request that auto-merges once
+# CI passes. This replaces Dependabot's npm updates; GitHub Actions updates
+# stay with Dependabot (see .github/dependabot.yml).
+#
+# Authenticates with PERSONAL_ACCESS_TOKEN (the same Actions secret used by
+# sync-agent-config.yml) so that the push triggers the push-based CI workflows
+# and the repository owner (a ruleset bypass actor) can auto-merge.
+
+on:
+  schedule:
+    # Weekly, Saturday 06:07 JST (Friday 21:07 UTC) — lands before the weekend.
+    - cron: '7 21 * * 5'
+
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  pnpm-update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Do not persist any token in the git config: `pnpm install` below runs
+          # dependency lifecycle scripts, and the PAT must not be exposed to them.
+          # It is supplied inline only for the final push.
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: 'package.json'
+          cache: 'pnpm'
+
+      - name: Update pnpm itself
+        run: pnpm self-update
+
+      - name: Update dependencies
+        run: |
+          pnpm run update-packages
+          pnpm install --no-frozen-lockfile
+
+      - name: Open auto-merge PR if anything changed
+        env:
+          GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: |
+          # `git status --porcelain` (not `git diff --quiet`) so untracked files
+          # created by the update are detected too.
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "Dependencies already up to date; nothing to do."
+            exit 0
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          branch="chore/pnpm-update-$(date -u +%Y%m%d)"
+          git switch -c "$branch"
+          git add -A
+          git commit -m "fix: update dependencies"
+
+          # Authenticate the push inline so the PAT is never written to git config.
+          git push --force-with-lease \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:refs/heads/${branch}"
+
+          if ! gh pr view "$branch" >/dev/null 2>&1; then
+            gh pr create \
+              --base main \
+              --head "$branch" \
+              --title "fix: update dependencies" \
+              --body "Automated weekly dependency update via \`pnpm run update-packages\` + \`pnpm self-update\`. Auto-merges once CI passes."
+          fi
+          gh pr merge --auto --squash "$branch"


### PR DESCRIPTION
Self-hosted weekly dependency updates, replacing Dependabot's npm updates.

- **.github/workflows/pnpm-update.yml** (new): weekly (Sat 06:07 JST) + workflow_dispatch. Runs `pnpm run update-packages` + `pnpm self-update` and opens one bundled auto-merge PR. Auth via `PERSONAL_ACCESS_TOKEN` (no new secrets); PAT scoped to the push only.
- **.github/dependabot.yml**: drop the `npm` ecosystem (now handled by the workflow); keep `github-actions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)