### PR TITLE
fix: stop npm publish in the release flow

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -47,9 +47,20 @@ export default {
     ],
 
     // 4-a. Update the version field in package.json with the next version number.
-    // 4-b. Publish the package to npmjs.
-    // 4-c. Run `npm dist-tag` command to add a tag to the package published on npmjs.
-    '@semantic-release/npm',
+    //
+    // NOTE: npmPublish: false にしている。このリポジトリはテンプレートで、
+    // release workflow も `--dry-run` 固定のため npm へ publish する運用になって
+    // いない（ npm 上の typescript-template は 2023-07 以降更新なし ）。
+    //
+    // npmPublish: true のままだと verifyConditions が npm 認証を要求する。
+    // npm 側にこのパッケージの trusted publisher が構成されていないため OIDC の
+    // token exchange が 404 になり、NPM_TOKEN も無いため
+    // "No npm token specified." で落ちる。
+    //
+    // 実際に publish する運用へ戻す場合は、npm 側で trusted publisher
+    // （ repository: noshiro-pf/typescript-template, workflow: release.yml ）を
+    // 設定したうえで npmPublish: true に戻すこと。
+    { path: '@semantic-release/npm', npmPublish: false },
 
     // 5. Commit the changes of assets generated during the release flow to the repository.
     [


### PR DESCRIPTION
release workflow が semantic-release の verifyConditions で失敗していた。

  [@semantic-release/npm] OIDC token exchange with the npm registry failed:
                          404 OIDC token exchange error - package not found
  ✘ ENONPMTOKEN No npm token specified.

@semantic-release/npm は OIDC を先に試し、失敗するとトークン認証へ
フォールバックする。npm 上にこのパッケージの trusted publisher が構成されて
いないため OIDC が 404 になり、NPM_TOKEN も（ trusted publishing 移行に伴い ）
削除済みのため両方の経路が塞がっていた。

このリポジトリはテンプレートで、release workflow も `--dry-run` 固定のため
npm へ publish する運用になっていない（ npm 上の typescript-template は
2023-07 以降更新なし ）。npmPublish: false にして構成と実態を一致させる。
バージョン更新・CHANGELOG 生成・GitHub Release は従来どおり動く。

実際に publish する運用へ戻す場合は、npm 側で trusted publisher
（ repository: noshiro-pf/typescript-template, workflow: release.yml ）を
設定したうえで npmPublish: true に戻すこと。

検証: ローカルで `semantic-release --dry-run` を実行し、verifyConditions が
全プラグインで通り ENONPMTOKEN が出ないことを確認した。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)