### PR TITLE
fix(ci): stop pnpm-update from taking GitHub Action majors

### DIFF
--- a/.github/workflows/pnpm-update.yml
+++ b/.github/workflows/pnpm-update.yml
@@ -1,10 +1,27 @@
 name: Weekly pnpm update
 
-# Runs this repository's own `update-packages` script (which encodes the
-# skip rules such as `!eslint` / `!typescript`) together with `pnpm
-# self-update`, and opens a single bundled pull request that auto-merges once
-# CI passes. This replaces Dependabot's npm updates; GitHub Actions updates
-# stay with Dependabot (see .github/dependabot.yml).
+# Runs this repository's own `update-packages` and `update-actions` scripts
+# together with `pnpm self-update`, and opens a single bundled pull request that
+# auto-merges once CI passes. This replaces Dependabot entirely: the npm
+# dependencies come from `update-packages` (whose skip rules —
+# `update.ignoreDeps`, `minimumReleaseAge` — live in pnpm-workspace.yaml), and
+# the action pins in `.github/workflows/` come from `update-actions`. There is
+# no .github/dependabot.yml.
+#
+# The action pins move in a second, separate step. `update.githubActions` is
+# deliberately `false`, so `update-packages` — which carries `--latest` — leaves
+# them alone, and `update-actions` turns the check back on per-invocation with
+# `--include-github-actions`. That second command has no `--latest`, so an
+# action only moves within `^current`: a major stays put until a human takes it.
+# `changesets/action` v2 is why. It requires Changesets CLI v3 and renamed every
+# input, so the major landing unattended broke release.yml in the sibling
+# repositories that share this setup, and neither `minimumReleaseAge` nor
+# `ignoreDeps` applies to actions (pnpm reads their versions from
+# `git ls-remote` refs, which carry no publication date).
+#
+# Because that step rewrites files under .github/workflows/, the token below has
+# to carry the `workflows` permission, or the push is rejected the moment an
+# action pin moves.
 #
 # Authenticates with a GitHub App installation token (the same App used by
 # sync-agent-config.yml) so that the push triggers the push-based CI workflows
@@ -50,6 +67,7 @@ jobs:
       - name: Update dependencies
         run: |
           pnpm run update-packages
+          pnpm run update-actions
           pnpm install --no-frozen-lockfile
 
       # 依存更新が終わってからトークンを発行する。許可済みビルドスクリプトが
@@ -62,6 +80,10 @@ jobs:
           private-key: ${{ secrets.REPO_AUTOMATION_BOT_PRIVATE_KEY }}
           permission-contents: write # ブランチの push
           permission-pull-requests: write # PR の作成と auto-merge の有効化
+          # `update-actions` により .github/workflows/ の action ピンも
+          # 更新されるため、これが無いと push が
+          # 「refusing to allow a GitHub App to create or update workflow ...」で拒否される。
+          permission-workflows: write # workflow ファイルを含むコミットの push
 
       - name: Open auto-merge PR if anything changed
         env:
@@ -92,6 +114,6 @@ jobs:
               --base main \
               --head "$branch" \
               --title "fix: update dependencies" \
-              --body "Automated weekly dependency update via \`pnpm run update-packages\` + \`pnpm self-update\`. Auto-merges once CI passes."
+              --body "Automated weekly dependency update via \`pnpm run update-packages\` + \`pnpm run update-actions\` + \`pnpm self-update\`. Action pins move within \`^current\` only, so a major waits for a human. Auto-merges once CI passes."
           fi
           gh pr merge --auto --squash "$branch"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -493,3 +493,28 @@ Types such as `DeepReadonly`, `StrictOmit`, `ReadonlyRecord` etc. are installed 
 ## Repository Guidelines
 
 In addition to the common instructions above (vendored into `agents/common-rules.md` from the common-agent-config repository), project-specific rules are shown below.
+
+### Dependency updates
+
+`pnpm-update.yml` runs weekly and opens a single bundled pull request that
+auto-merges once CI passes. What it holds back lives in `pnpm-workspace.yaml`
+(`update.ignoreDeps`, `minimumReleaseAge`) — that is the single source of truth
+for it; do not add exclusion arguments to the `update-packages` script.
+
+**GitHub Action pins are updated by `pnpm run update-actions`, not by
+`update-packages`.** `update.githubActions` is `false` so that
+`update-packages`, which carries `--latest`, leaves the workflow files alone;
+`update-actions` turns the check back on with `--include-github-actions` and
+deliberately omits `--latest`, so an action only moves within `^current` and a
+major waits for a human. Do not set `update.githubActions` back to `true`, and
+do not add `--latest` to `update-actions`: `changesets/action` v2 requires
+Changesets CLI v3 and renamed every input, so taking that major unattended
+broke `release.yml` in the sibling repositories that share this setup.
+
+Neither `minimumReleaseAge` nor `update.ignoreDeps` applies to actions. pnpm
+resolves action versions from `git ls-remote` refs, which carry a tag name and a
+SHA but no publication date, so there is nothing for the age check to read — a
+tag hours old is taken regardless. Hold an action back by leaving the major
+alone, not by listing it in `ignoreDeps`.
+`pnpm outdated --include-github-actions --latest` lists the majors that are
+waiting.

--- a/agents/local-rules.md
+++ b/agents/local-rules.md
@@ -1,3 +1,28 @@
 # Repository Guidelines
 
 In addition to the common instructions above (vendored into `agents/common-rules.md` from the common-agent-config repository), project-specific rules are shown below.
+
+## Dependency updates
+
+`pnpm-update.yml` runs weekly and opens a single bundled pull request that
+auto-merges once CI passes. What it holds back lives in `pnpm-workspace.yaml`
+(`update.ignoreDeps`, `minimumReleaseAge`) — that is the single source of truth
+for it; do not add exclusion arguments to the `update-packages` script.
+
+**GitHub Action pins are updated by `pnpm run update-actions`, not by
+`update-packages`.** `update.githubActions` is `false` so that
+`update-packages`, which carries `--latest`, leaves the workflow files alone;
+`update-actions` turns the check back on with `--include-github-actions` and
+deliberately omits `--latest`, so an action only moves within `^current` and a
+major waits for a human. Do not set `update.githubActions` back to `true`, and
+do not add `--latest` to `update-actions`: `changesets/action` v2 requires
+Changesets CLI v3 and renamed every input, so taking that major unattended
+broke `release.yml` in the sibling repositories that share this setup.
+
+Neither `minimumReleaseAge` nor `update.ignoreDeps` applies to actions. pnpm
+resolves action versions from `git ls-remote` refs, which carry a tag name and a
+SHA but no publication date, so there is nothing for the age check to read — a
+tag hours old is taken regardless. Hold an action back by leaving the major
+alone, not by listing it in `ignoreDeps`.
+`pnpm outdated --include-github-actions --latest` lists the majors that are
+waiting.

--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
     "tsc": "node ./node_modules/typescript-native/bin/tsc --noEmit",
     "tscw": "node ./node_modules/typescript-native/bin/tsc --noEmit --watch -p ./tsconfig.json",
     "type-check": "node ./node_modules/typescript-native/bin/tsc --noEmit",
+    "update-actions": "pnpm update --recursive --include-github-actions \"*/*\"",
+    "update-packages": "pnpm update --latest --recursive",
     "z:vitest": "vitest --config ./configs/vitest.config.mts",
     "z:vitest:node": "pnpm run z:vitest --project='Node.js'"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,14 @@
 update:
-  githubActions: true
+  # GitHub Actions のピンは `update-packages` ではなく `update-actions` が動かす。
+  # ここを true にすると `--latest` の付いた `update-packages` が actions も
+  # メジャー更新してしまい、`changesets/action` v1 → v2 のような、設定の書き換えを
+  # 伴う更新が無人でマージされる。`update-actions` は `--latest` を付けないので
+  # `^current` の範囲に留まり、メジャー更新は人間が判断することになる。
+  #
+  # `minimumReleaseAge` は actions には効かない。pnpm は actions のバージョンを
+  # `git ls-remote` の ref 一覧から取っており、タグの作成日時を持たないため。
+  # 同じ理由で下の `ignoreDeps` も actions には適用されない。
+  githubActions: false
   ignoreDeps:
     - typescript
 


### PR DESCRIPTION
Ports the fix that landed in [mono#1608](https://github.com/noshiro-pf/mono/pull/1608) and [strict-typescript-lib#109](https://github.com/noshiro-pf/strict-typescript-lib/pull/109).

## Problem

`pnpm update --latest` reaches the action pins under `.github/workflows/` whenever `update.githubActions` is `true`, and a major taken that way merges unattended. In the sibling repositories that is exactly what happened: `changesets/action` went from v1.9.0 to v2, which requires Changesets CLI v3 and renamed every input, and release stayed broken on `main` until a human reverted the pin.

Neither guard here would have caught it. pnpm resolves action versions from `git ls-remote` refs, which carry a tag name and a SHA but no publication date, so `minimumReleaseAge` has nothing to read, and `update.ignoreDeps` is never passed to the actions code path at all.

## What changed

What does separate a major from a minor is `--latest`. Without it the actions updater picks the highest tag satisfying `^current`, so a major stays put. The update is now split in two:

- `pnpm-workspace.yaml` — `update.githubActions: false`, keeping the `--latest` run away from the workflow files.
- `package.json` — new `update-actions` script: `pnpm update --recursive --include-github-actions "*/*"`, **without** `--latest`. Passing only an action selector also keeps it from touching npm dependencies.
- `.github/workflows/pnpm-update.yml` — runs `update-actions` as a second step, and the App token gains `permission-workflows: write`; without it the push is rejected the moment an action pin moves. The header comment is corrected too (it claimed action updates stayed with Dependabot, and there is no `.github/dependabot.yml`).
- `agents/local-rules.md` / `AGENTS.md` — the rule is written down: do not set `update.githubActions` back to `true`, do not add `--latest` to `update-actions`, and hold an action back by leaving the major alone rather than by listing it in `ignoreDeps`.

### Drive-by fix

`pnpm-update.yml` has always invoked `pnpm run update-packages`, but that script did not exist in `package.json`, so the workflow could only ever have failed at that step. It is added here alongside `update-actions`.

## Verification

`pnpm run update-actions` run against this checkout moves `anthropics/claude-code-action` v1.0.189 → v1.0.193 — inside `^1`, which is the point — and leaves every other pin and every npm dependency alone. That bump is reverted in this branch rather than carried, so the change here is only the mechanism; the weekly run will take it. `pnpm run fmt`, `pnpm run md` and `pnpm run cspell` are clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K3jCUgDfLXHP2iM83XosJr)_