### PR TITLE
fix(ci): reuse one pnpm-update branch and bound the auto-fix retries

### DIFF
--- a/.github/workflows/auto-fix-pnpm-update.yml
+++ b/.github/workflows/auto-fix-pnpm-update.yml
@@ -2,7 +2,7 @@ name: Auto-fix pnpm update
 
 # Runs Claude against a failing dependency update.
 #
-# pnpm-update.yml opens `chore/pnpm-update-<date>` every week and auto-merges it
+# pnpm-update.yml rebuilds `chore/pnpm-update` every week and auto-merges it
 # once CI passes, so the update itself needs no attention — but the follow-up
 # work does, and it is the same shape every time: a major adds a lint rule, or
 # renames an API, and the pull request sits red until someone makes the small
@@ -84,12 +84,26 @@ name: Auto-fix pnpm update
 # would let any bot that can trigger one of the workflows above start Claude
 # with the App token.
 #
-# ## Why the attempt is capped
+# ## The retry loop, and why it is capped
 #
-# Claude's fix lands on the branch, CI re-runs, and a still-failing run would
-# trigger this workflow again. The cap counts commits already made here — the
-# `fix(deps):` prefix is what marks them — and stops at two. Each weekly run
-# opens a branch under a new date, so the count starts from zero again.
+# There is no loop construct here — the retry is the trigger. Claude's fix
+# lands on the branch, the push re-runs CI, and a still-failing run arrives back
+# here as another `workflow_run`. So it keeps going by itself until CI is green,
+# which is why nothing needs to poll or wait.
+#
+# Two things stop it, and both are meant to.
+#
+#   - **`MAX_FIX_ATTEMPTS`.** The cap counts the commits already made here — the
+#     `fix(deps):` prefix is what marks them. pnpm-update.yml rebuilds the
+#     branch from main every week and force-pushes, which discards those
+#     commits, so the count is back to zero on each weekly update rather than
+#     accumulating across them.
+#   - **Claude committing nothing.** When the cause is outside this repository
+#     or the call is a policy one, it is told to comment instead of committing.
+#     No commit means no push, no CI, and no further trigger — the loop ends on
+#     its own, which is the right outcome. Re-running it would only reproduce
+#     the same reasoning, so a red pull request with an explanation on it is
+#     where it is supposed to stop.
 
 on:
   workflow_run:
@@ -125,6 +139,12 @@ on:
 # takes the newest failure on the branch, which is as likely to be some
 # unrelated workflow as the CI failure the update actually caused.
 env:
+  # How many `fix(deps):` commits this may leave on one update branch before it
+  # stops and leaves the pull request for a human. See the header comment: the
+  # retry itself is the `workflow_run` trigger, so this is the only thing
+  # bounding it when Claude keeps committing without turning CI green.
+  MAX_FIX_ATTEMPTS: '3'
+
   WATCHED_WORKFLOWS: |
     Weekly pnpm update
     Lint and Build
@@ -289,6 +309,14 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Assigned rather than piped into `wc`, so that a failing `git log`
+          # stops the job instead of counting zero and starting over.
+          previous="$(git log --format='%s' origin/main..HEAD --grep='^fix(deps): ')"
+          count="$(printf '%s' "$previous" | grep -c . || true)"
+
+          echo "Attempts so far: ${count} of ${MAX_FIX_ATTEMPTS}"
+          echo "attempt=$((count + 1))" >> "$GITHUB_OUTPUT"
+
           # The cap exists to stop this from retrying unattended. A person
           # pressing the button is attended, so a manual run overrides it.
           if [ "${EVENT_NAME}" = 'workflow_dispatch' ]; then
@@ -297,18 +325,12 @@ jobs:
             exit 0
           fi
 
-          # Assigned rather than piped into `wc`, so that a failing `git log`
-          # stops the job instead of counting zero and starting over.
-          previous="$(git log --format='%s' origin/main..HEAD --grep='^fix(deps): ')"
-          count="$(printf '%s' "$previous" | grep -c . || true)"
-
-          echo "Attempts so far: ${count}"
-
-          if [ "$count" -ge 2 ]; then
+          if [ "$count" -ge "${MAX_FIX_ATTEMPTS}" ]; then
             {
               echo '### Gave up'
               echo
-              echo "Already tried ${count} times on this branch; leaving it for a human."
+              echo "Already tried ${count} times on this branch, which is the limit"
+              echo '(`MAX_FIX_ATTEMPTS`); leaving it for a human.'
             } >> "$GITHUB_STEP_SUMMARY"
             echo 'proceed=false' >> "$GITHUB_OUTPUT"
           else
@@ -351,6 +373,11 @@ jobs:
             You are on that branch, with dependencies installed. Read the
             failing run's logs, then make the follow-up change the update needs
             and commit it to this branch.
+
+            This is attempt ${{ steps.attempts.outputs.attempt }} of
+            ${{ env.MAX_FIX_ATTEMPTS }}. Any `fix(deps):` commits already on the
+            branch are earlier attempts that did not turn CI green — read them
+            first, and do not retry an approach that has already been tried.
 
             Follow `AGENTS.md` — it is the instructions for this repository.
             Note that `AGENTS.md` is generated: edit `agents/local-rules.md`

--- a/.github/workflows/pnpm-update.yml
+++ b/.github/workflows/pnpm-update.yml
@@ -26,6 +26,16 @@ name: Weekly pnpm update
 # Authenticates with a GitHub App installation token (the same App used by
 # sync-agent-config.yml) so that the push triggers the push-based CI workflows
 # and the repository owner (a ruleset bypass actor) can auto-merge.
+#
+# ## One branch, reused
+#
+# The branch is `chore/pnpm-update` with no date in it, and every run rebuilds
+# it from a fresh checkout of main and force-pushes. A week that lands no fix
+# therefore does not leave a stale pull request behind for the next one to sit
+# beside — there is only ever one open, and it is always rebased onto main.
+#
+# Reusing the name is what makes the two details below matter; with a new dated
+# branch each week neither could bite, because the branch never already existed.
 
 on:
   schedule:
@@ -99,21 +109,44 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-          branch="chore/pnpm-update-$(date -u +%Y%m%d)"
+          # A fixed branch name, not one carrying the date: every run starts from
+          # a fresh checkout of main, so force-pushing here both refreshes the
+          # open pull request and rebases it, instead of leaving last week's
+          # behind and opening another one.
+          branch="chore/pnpm-update"
           git switch -c "$branch"
           git add -A
           git commit -m "fix: update dependencies"
 
           # Authenticate the push inline so the PAT is never written to git config.
-          git push --force-with-lease \
-            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+          remote_url="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          # `--force-with-lease` with no value compares against the
+          # remote-tracking ref, and `actions/checkout` configures a fetch
+          # refspec for the default branch alone — so this branch has none, and
+          # the push is rejected with "stale info" every run after the one that
+          # creates it. Naming the expected value restores the protection: an
+          # empty value means "expect it not to exist", which is what the first
+          # run wants.
+          # Two steps rather than a pipeline, so that a failed `ls-remote` stops
+          # the job instead of yielding an empty lease and force-pushing anyway
+          # — a pipeline would report `cut`'s exit status, which is always 0.
+          remote_ref="$(git ls-remote "$remote_url" "refs/heads/${branch}")"
+          expected="$(printf '%s' "$remote_ref" | cut -f1)"
+
+          git push --force-with-lease="refs/heads/${branch}:${expected}" \
+            "$remote_url" \
             "HEAD:refs/heads/${branch}"
 
-          if ! gh pr view "$branch" >/dev/null 2>&1; then
+          # By branch name alone `gh pr view` also finds a merged pull request,
+          # and the branch is recreated every run — so once the first one
+          # merges, this would skip creating the next and then fail trying to
+          # auto-merge a closed pull request. Ask for an open one.
+          if [ "$(gh pr view "$branch" --json state --jq .state 2>/dev/null)" != 'OPEN' ]; then
             gh pr create \
               --base main \
               --head "$branch" \
               --title "fix: update dependencies" \
-              --body "Automated weekly dependency update via \`pnpm run update-packages\` + \`pnpm run update-actions\` + \`pnpm self-update\`. Action pins move within \`^current\` only, so a major waits for a human. Auto-merges once CI passes."
+              --body "Automated weekly dependency update via \`pnpm run update-packages\` + \`pnpm run update-actions\` + \`pnpm self-update\`. Action pins move within \`^current\` only, so a major waits for a human. Rebuilt from main on every run, so force-pushes to this branch are expected. Auto-merges once CI passes."
           fi
           gh pr merge --auto --squash "$branch"


### PR DESCRIPTION
Follows #336 and #337.

## 1. Why PR #335 is still red — not a bug

The auto-fix run succeeded and **deliberately committed nothing**.
`ts-codemod-lib` 3.0.0 moved its CLI binaries (`append-as-const` and friends)
into a companion package `ts-codemod-cli`, which was published 2026-08-12 and
so does not clear this repo's own `minimumReleaseAge` of 7 days until about
2026-08-19. Claude diagnosed that, laid out three options — wait, add it to
`minimumReleaseAgeExclude`, or revert `ts-codemod-lib` — and left the pull
request red rather than picking a repository-policy answer unilaterally. That
is exactly what the prompt tells it to do.

**Looping would not have helped**, and this PR does not change that. A declined
fix ends the loop by design; re-running only reproduces the same reasoning. The
header comment now states that distinction explicitly, so the next reader does
not mistake it for a stalled retry.

Deciding #335 is a call for you: waiting until ~2026-08-19 is the zero-risk
option.

## 2. One branch, reused (ported from `../mono`)

`chore/pnpm-update-<date>` → `chore/pnpm-update`. Every run still starts from a
fresh checkout of main, so the force-push both refreshes the open pull request
and rebases it, instead of leaving last week's behind and opening another
beside it.

Two details come with the rename. Neither could bite while the branch name was
new every week, and `mono` already carries both:

| detail | what breaks without it |
| :-- | :-- |
| `--force-with-lease` needs an explicit expected value | `actions/checkout` sets a fetch refspec for the default branch only, so a reused branch has no remote-tracking ref and every run after the first is rejected with "stale info" |
| `gh pr view` must check for `OPEN` | it matches merged pull requests by branch name too, so after the first merge this would skip creating the next, then fail auto-merging a closed one |

## 3. The retry limit is named and raised

The retry was never a loop construct — Claude's commit re-runs CI, and a
still-red run comes back as another `workflow_run`. The cap was the only thing
bounding it, so it moves from a bare `2` to `MAX_FIX_ATTEMPTS: '3'`, beside the
other workflow-level constants. The prompt now also tells Claude which attempt
it is on, and that the `fix(deps):` commits already on the branch are earlier
attempts that did not work.

Reusing the branch does not break the cap's reset: the weekly run rebuilds from
main and force-pushes, discarding those commits, so the count starts from zero
each week rather than accumulating across them.

## Verification

- Both workflows parse; every `run:` block passes `bash -n`; cspell clean.
- The `WATCHED_WORKFLOWS` list is asserted to still equal
  `on.workflow_run.workflows`.
- **Attempt cap** exercised against a real git repo at `MAX_FIX_ATTEMPTS=3`:

  | prior `fix(deps):` commits | result |
  | :-- | :-- |
  | 0 / 1 / 2 | `attempt=1/2/3`, proceeds |
  | 3 / 4 | stops, "Gave up" summary |
  | 4, manual dispatch | proceeds (override) |

- **Push logic** exercised against a local bare remote: week 1 creates the
  branch with an empty lease, week 2 force-pushes over it using the
  `ls-remote` value. I did not independently verify that a *stale* lease is
  rejected — that is git's documented behaviour, not this workflow's logic.

## One consequence worth confirming

Rebuilding the branch weekly means force-pushing over whatever is on it. If
someone pushes a manual fix to `chore/pnpm-update` and it is not merged before
the next weekly run, that work is discarded. This is how `mono` already
operates and the pull request body says so, but with dated branches it could
not happen.

Also note the existing `chore/pnpm-update-20260815` branch and #335 are not
touched by this. Once merged, the next weekly run opens a separate
`chore/pnpm-update`; #335 needs merging or closing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9DME94jUsSf5nsAgDb9WC
